### PR TITLE
webrepl.html: Deselect previously selected file before reading

### DIFF
--- a/webrepl.html
+++ b/webrepl.html
@@ -335,6 +335,10 @@ function handle_put_file_select(evt) {
     reader.readAsArrayBuffer(f);
 }
 
+document.getElementById('put-file-select').addEventListener('click', function(){
+    this.value = null;
+}, false);
+
 document.getElementById('put-file-select').addEventListener('change', handle_put_file_select, false);
 document.getElementById('put-file-button').disabled = true;
 


### PR DESCRIPTION
Without this, when you select a file, make modifications and select the same file again, it does not read the latest changes, as the file inputs `change` event does not fire.

To work around, you have to select a different file, or cancel the file dialog to clear the field's value before trying your modified file again.