### PR TITLE
Preserve websocket server IP over reloading the web page.

### DIFF
--- a/webrepl.html
+++ b/webrepl.html
@@ -97,19 +97,19 @@ function calculate_size(win) {
 
 (function() {
     window.onload = function() {
-      var url = window.location.hash.substring(1);
-      if(url) {
-      	document.getElementById('url').value = 'ws://' + url;
-      }
-      var size = calculate_size(self);
-      term = new Terminal({
-        cols: size[0],
-        rows: size[1],
-        useStyle: true,
-        screenKeys: true,
-        cursorBlink: false
-      });
-      term.open(document.getElementById("term"));
+        var url = window.location.hash.substring(1);
+        if(url) {
+            document.getElementById('url').value = 'ws://' + url;
+        }
+        var size = calculate_size(self);
+        term = new Terminal({
+            cols: size[0],
+            rows: size[1],
+            useStyle: true,
+            screenKeys: true,
+            cursorBlink: false
+        });
+        term.open(document.getElementById("term"));
     };
     window.addEventListener('resize', function() {
         var size = calculate_size(self);

--- a/webrepl.html
+++ b/webrepl.html
@@ -97,6 +97,10 @@ function calculate_size(win) {
 
 (function() {
     window.onload = function() {
+      var url = window.location.hash.substring(1);
+      if(url) {
+      	document.getElementById('url').value = 'ws://' + url;
+      }
       var size = calculate_size(self);
       term = new Terminal({
         cols: size[0],
@@ -134,6 +138,7 @@ function update_file_status(s) {
 }
 
 function connect(url) {
+    window.location.hash = url.substring(5);
     ws = new WebSocket(url);
     ws.binaryType = 'arraybuffer';
     ws.onopen = function() {


### PR DESCRIPTION
I got tired of re-entering my ESP's IP every time I had to reload the web page. This simple modification allows you to specify it in the URL, and it also automatically stores it there on connect.
