### PR TITLE
Detach ws from term when closed

### DIFF
--- a/webrepl.html
+++ b/webrepl.html
@@ -237,6 +237,7 @@ function connect(url) {
         if (term) {
             term.write('\x1b[31mDisconnected\x1b[m\r\n');
         }
+        term.off('data');
         prepare_for_connect();
     }
 }


### PR DESCRIPTION
Stops console error `WebSocket is already in CLOSING or CLOSED state.` from showing when you interact with a disconnected terminal (that was once connected).