### PR TITLE
Cannot type characters with option key on macOS

### DIFF
--- a/term.js
+++ b/term.js
@@ -2835,7 +2835,7 @@ Terminal.prototype.keyDown = function(ev) {
           // ^] - group sep
           key = String.fromCharCode(29);
         }
-      } else if (ev.altKey) {
+      } else if (ev.altKey && !this.isMac) {
         if (ev.keyCode >= 65 && ev.keyCode <= 90) {
           key = '\x1b' + String.fromCharCode(ev.keyCode + 32);
         } else if (ev.keyCode === 192) {
@@ -2895,7 +2895,7 @@ Terminal.prototype.keyPress = function(ev) {
     return false;
   }
 
-  if (!key || ev.ctrlKey || ev.altKey || ev.metaKey) return false;
+  if (!key || ev.ctrlKey || (ev.altKey && !this.isMac) || ev.metaKey) return false;
 
   key = String.fromCharCode(key);
 


### PR DESCRIPTION
In the HTML client, I am unable to type vital characters like `[` or `\`, because on my Swiss Mac keyboard layout, these are typed as combinations involving the option key (`[` is option-5, `\` is option-shift-7), and the terminal widget intercepts the option key (mapped to “alt” in the event API) and uses it to send escape sequences instead. This may be appropriate for the alt key on a PC, but it is not appropriate for the option key on a Mac, which is a character modifier, not a command modifier.

The attached commit disables this behavior on macOS, allowing almost all printable ASCII characters to be typed. (There is still a problem with those involving dead-key combinations, like `~`, but fortunately these are rarer in Python.)

It is possible that the issue could also be fixed by upgrading to a more recent version of xterm.js, but this is a quick and simple fix.

I have been using this for months on Safari with no adverse effects noticed, and have also briefly tested it on Firefox and Chromium.