### PR TITLE
Use urllib to parse the URL for the host and port

### DIFF
--- a/webrepl_cli.py
+++ b/webrepl_cli.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import sys
 import os
 import struct
+from urllib.parse import urlparse
 try:
     import usocket as socket
 except ImportError:
@@ -185,8 +186,9 @@ def parse_remote(remote):
         fname = "/"
     port = 8266
     if ":" in host:
-        host, port = host.split(":")
-        port = int(port)
+        url = urlparse(host)
+        host = url.hostname
+        port = url.port
     return (host, port, fname)
 
 


### PR DESCRIPTION
Parse the received URL string with urllib.parse.urlparse() to extract the hostname and port number (instead of splitting the URL to extract the hostname and port).

parse_remote() previously split the host string with ":" to get the host and port number, but splitting may result in a list of 3 strings (e.g., 'ws://192.168.4.1:8266'  would become ['ws', '//192.168.4.1', '8266']. The code would crash because of the double forward slashes at the beginning of the host string.